### PR TITLE
[UOD-1228] add support for native serialization

### DIFF
--- a/abidecoder.go
+++ b/abidecoder.go
@@ -12,6 +12,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var NativeType = false
+
 func (a *ABI) DecodeAction(data []byte, actionName ActionName) ([]byte, error) {
 	binaryDecoder := NewDecoder(data)
 	action := a.ActionForName(actionName)
@@ -43,13 +45,17 @@ func (a *ABI) DecodeTableRow(tableName TableName, data []byte) ([]byte, error) {
 }
 
 func (a *ABI) DecodeTableRowTyped(tableType string, data []byte) ([]byte, error) {
-	binaryDecoder := NewDecoder(data)
-	builtStruct, err := a.decode(binaryDecoder, tableType)
+	builtStruct, err := a.DecodeTableRowTypedNative(tableType, data)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(builtStruct)
 
+}
+
+func (a *ABI) DecodeTableRowTypedNative(tableType string, data []byte) (map[string]interface{}, error) {
+	binaryDecoder := NewDecoder(data)
+	return a.decode(binaryDecoder, tableType)
 }
 
 func (a *ABI) Decode(binaryDecoder *Decoder, structName string) ([]byte, error) {
@@ -328,20 +334,33 @@ func (a *ABI) read(binaryDecoder *Decoder, fieldType string) (interface{}, error
 	case "time_point":
 		timePoint, e := binaryDecoder.ReadTimePoint() //todo double check
 		if e == nil {
-			value = formatTimePoint(timePoint, a.fitNodeos)
+			if NativeType {
+				value = time.Unix(0, int64(timePoint*1000)).UTC()
+			} else {
+				value = formatTimePoint(timePoint, a.fitNodeos)
+			}
 		}
 		err = e
 	case "time_point_sec":
 		timePointSec, e := binaryDecoder.ReadTimePointSec()
 		if e == nil {
-			t := time.Unix(int64(timePointSec), 0)
-			value = t.UTC().Format("2006-01-02T15:04:05")
+			t := time.Unix(int64(timePointSec), 0).UTC()
+			if NativeType {
+				value = t
+			} else {
+				value = t.UTC().Format("2006-01-02T15:04:05")
+			}
 		}
 		err = e
 	case "block_timestamp_type":
 		value, err = binaryDecoder.ReadBlockTimestamp()
 		if err == nil {
-			value = value.(BlockTimestamp).Time.UTC().Format("2006-01-02T15:04:05")
+			t := value.(BlockTimestamp).Time.UTC()
+			if NativeType {
+				value = t
+			} else {
+				value = t.Format("2006-01-02T15:04:05")
+			}
 		}
 	case "name":
 		value, err = binaryDecoder.ReadName()

--- a/abidecoder_test.go
+++ b/abidecoder_test.go
@@ -1202,6 +1202,11 @@ func TestABIDecoder_analyseFieldType(t *testing.T) {
 		{"field.type.1[]?$", "field.type.1", true, true, true},
 		{"field.type.1[]$", "field.type.1", false, true, true},
 		{"field.type.1[]?", "field.type.1", true, true, false},
+		{"field.type.2[]?", "field.type.2", true, true, false},
+		{"field.type.1?$", "field.type.1", true, false, true},
+		{"field.type.1[]$", "field.type.1", false, true, true},
+		{"field.type.3[]?$", "field.type.3", true, true, true},
+		{"uint32?$", "uint32", true, false, true},
 	}
 
 	for i, test := range testCases {

--- a/types.go
+++ b/types.go
@@ -22,6 +22,8 @@ import (
 var symbolRegex = regexp.MustCompile("^[0-9],[A-Z]{1,7}$")
 var symbolCodeRegex = regexp.MustCompile("^[A-Z]{1,7}$")
 
+var LegacyJSON4Asset = true
+
 // For reference:
 // https://github.com/mithrilcoin-io/EosCommander/blob/master/app/src/main/java/io/mithrilcoin/eoscommander/data/remote/model/types/EosByteWriter.java
 
@@ -62,23 +64,23 @@ type AccountResourceLimit struct {
 }
 
 type DelegatedBandwidth struct {
-	From      AccountName `json:"from"`
-	To        AccountName `json:"to"`
-//ultra-andrey-bezrukov --- BLOCK-80 Integrate ultra power into dfuse and remove rex related tables
-//NetWeight and CPUWeight are left inplace (moved to bottom) in order to avoid unimportant changes in eosc and bringing in a new repo
-	PowerWeight Asset     `json:"power_weight"`
-	NetWeight Asset       `json:"net_weight"`
-	CPUWeight Asset       `json:"cpu_weight"`
+	From AccountName `json:"from"`
+	To   AccountName `json:"to"`
+	//ultra-andrey-bezrukov --- BLOCK-80 Integrate ultra power into dfuse and remove rex related tables
+	//NetWeight and CPUWeight are left inplace (moved to bottom) in order to avoid unimportant changes in eosc and bringing in a new repo
+	PowerWeight Asset `json:"power_weight"`
+	NetWeight   Asset `json:"net_weight"`
+	CPUWeight   Asset `json:"cpu_weight"`
 }
 
 type TotalResources struct {
-	Owner     AccountName `json:"owner"`
-//ultra-andrey-bezrukov --- BLOCK-80 Integrate ultra power into dfuse and remove rex related tables
-//NetWeight and CPUWeight are left inplace (moved to bottom) in order to avoid unimportant changes in eosc and bringing in a new repo
-	PowerWeight Asset     `json:"power_weight"`
-	RAMBytes  Int64       `json:"ram_bytes"`
-	NetWeight Asset       `json:"net_weight"`
-	CPUWeight Asset       `json:"cpu_weight"`
+	Owner AccountName `json:"owner"`
+	//ultra-andrey-bezrukov --- BLOCK-80 Integrate ultra power into dfuse and remove rex related tables
+	//NetWeight and CPUWeight are left inplace (moved to bottom) in order to avoid unimportant changes in eosc and bringing in a new repo
+	PowerWeight Asset `json:"power_weight"`
+	RAMBytes    Int64 `json:"ram_bytes"`
+	NetWeight   Asset `json:"net_weight"`
+	CPUWeight   Asset `json:"cpu_weight"`
 }
 
 type VoterInfo struct {
@@ -96,9 +98,9 @@ type RefundRequest struct {
 	RequestTime JSONTime    `json:"request_time"` //         {"name":"request_time", "type":"time_point_sec"},
 	// ultra-keisuke-kanao --- BLOCK-1421 investigate preprod dfuse ultra.test account doesn't show in explorer
 	// Note that removing NetAmount and CPUAmount would require additional updates on github.com/eoscanada/eosc package.
-	PowerAmount Asset       `json:"power_amount"`
-	NetAmount   Asset       `json:"net_amount"`
-	CPUAmount   Asset       `json:"cpu_amount"`
+	PowerAmount Asset `json:"power_amount"`
+	NetAmount   Asset `json:"net_amount"`
+	CPUAmount   Asset `json:"cpu_amount"`
 }
 
 type CompressionType uint8
@@ -590,7 +592,17 @@ func (a *Asset) UnmarshalJSON(data []byte) error {
 }
 
 func (a Asset) MarshalJSON() (data []byte, err error) {
-	return json.Marshal(a.String())
+	if LegacyJSON4Asset {
+		return json.Marshal(a.String())
+	} else {
+		ratAmount := big.NewRat(int64(a.Amount), int64(math.Pow10(int(a.Symbol.Precision))))
+		amount, _ := ratAmount.Float64()
+		return json.Marshal(map[string]interface{}{
+			"amount":    amount,
+			"symbol":    a.Symbol.Symbol,
+			"precision": a.Symbol.Precision,
+		})
+	}
 }
 
 type Permission struct {
@@ -1493,8 +1505,9 @@ func (t fcVariantType) String() string {
 }
 
 // FIXME: Ideally, we would re-use `BaseVariant` but that requires some
-//        re-thinking of the decoder to make it efficient to read FCVariant types. For now,
-//        let's re-code it a bit to make it as efficient as possible.
+//
+//	re-thinking of the decoder to make it efficient to read FCVariant types. For now,
+//	let's re-code it a bit to make it as efficient as possible.
 type fcVariant struct {
 	TypeID fcVariantType
 	Impl   interface{}
@@ -1508,7 +1521,8 @@ func (a fcVariant) IsNil() bool {
 // and object, turning everything along the way in Go primitives types.
 //
 // **Note** For `Int64` and `Uint64`, we return `eos.Int64` and `eos.Uint64` types
-//          so that JSON marshalling is done correctly for large numbers
+//
+//	so that JSON marshalling is done correctly for large numbers
 func (a fcVariant) ToNative() interface{} {
 	if a.TypeID == fcVariantNullType ||
 		a.TypeID == fcVariantDoubleType ||

--- a/types_test.go
+++ b/types_test.go
@@ -389,6 +389,115 @@ func TestAssetToString(t *testing.T) {
 	}
 }
 
+func TestLegacyAssetToJSON(t *testing.T) {
+	LegacyJSON4Asset = true
+	tests := []struct {
+		in  Asset
+		out string
+	}{
+		// Haven't seen such a thing yet though..
+		{
+			Asset{6000000, Symbol{Precision: 4, Symbol: "EOS"}},
+			"\"600.0000 EOS\"",
+		},
+		{
+			Asset{-6000000, Symbol{Precision: 4, Symbol: "EOS"}},
+			"\"-600.0000 EOS\"",
+		},
+		{
+			Asset{10, Symbol{Precision: 5, Symbol: "SYS"}},
+			"\"0.00010 SYS\"",
+		},
+		{
+			Asset{-10, Symbol{Precision: 5, Symbol: "SYS"}},
+			"\"-0.00010 SYS\"",
+		},
+		{
+			Asset{6000, Symbol{Precision: 0, Symbol: "MAMA"}},
+			"\"6000 MAMA\"",
+		},
+		{
+			Asset{-6000, Symbol{Precision: 0, Symbol: "MAMA"}},
+			"\"-6000 MAMA\"",
+		},
+		{
+			Asset{0, Symbol{Precision: 255, Symbol: "EOS"}},
+			"\"0.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 EOS\"",
+		},
+	}
+
+	for _, test := range tests {
+		bytes, err := test.in.MarshalJSON()
+		if err != nil {
+			t.Error("MarshalJSON() error: %w", err)
+		}
+		assert.Equal(t, test.out, string(bytes))
+	}
+}
+
+func TestAssetToJSON(t *testing.T) {
+	LegacyJSON4Asset = false
+	tests := []struct {
+		in  Asset
+		out string
+	}{
+		// Haven't seen such a thing yet though..
+		{
+			Asset{6000000, Symbol{Precision: 4, Symbol: "EOS"}},
+			assertJson(t, 600, "EOS", 4),
+		},
+		{
+			Asset{-6000000, Symbol{Precision: 4, Symbol: "EOS"}},
+			assertJson(t, -600, "EOS", 4),
+		},
+		{
+			Asset{10, Symbol{Precision: 5, Symbol: "SYS"}},
+			assertJson(t, 0.0001, "SYS", 5),
+			// "\"0.00010 SYS\"",
+		},
+		{
+			Asset{-10, Symbol{Precision: 5, Symbol: "SYS"}},
+			assertJson(t, -0.0001, "SYS", 5),
+			// "\"-0.00010 SYS\"",
+		},
+		{
+			Asset{6000, Symbol{Precision: 0, Symbol: "MAMA"}},
+			assertJson(t, 6000, "MAMA", 0),
+			// "\"6000 MAMA\"",
+		},
+		{
+			Asset{-6000, Symbol{Precision: 0, Symbol: "MAMA"}},
+			assertJson(t, -6000, "MAMA", 0),
+			// "\"-6000 MAMA\"",
+		},
+		{
+			Asset{0, Symbol{Precision: 255, Symbol: "EOS"}},
+			assertJson(t, 0, "EOS", 255),
+		},
+	}
+
+	for _, test := range tests {
+		bytes, err := test.in.MarshalJSON()
+		if err != nil {
+			t.Error("MarshalJSON() error: %w", err)
+		}
+		assert.Equal(t, test.out, string(bytes))
+	}
+}
+
+func assertJson(t testing.TB, amount float64, symbol string, precision uint8) string {
+	t.Helper()
+	data, err := json.Marshal(map[string]interface{}{
+		"amount":    amount,
+		"symbol":    symbol,
+		"precision": precision,
+	})
+	if err != nil {
+		t.Fatal("json.Marshal error: %w", err)
+	}
+	return string(data)
+}
+
 func TestSimplePacking(t *testing.T) {
 	type S struct {
 		P string


### PR DESCRIPTION
This PR introduces native serialization of some specific data structures while only string transformation was available.
It allows us to work on more typed structures and prevent string parsing to extract the data.
One example is the `Asset` struct where only `100.01 UOS` string format was available and now you can work with a more structured json or for the time-based fields where you can get access to the native golang type instead of the string representation.